### PR TITLE
Prevent errors when evaluating classifiers for some data sets

### DIFF
--- a/src/clj_ml/classifiers.clj
+++ b/src/clj_ml/classifiers.clj
@@ -567,7 +567,7 @@
 (defn- collect-evaluation-results
   "Collects all the statistics from the evaluation of a classifier."
   ([class-labels ^Evaluation evaluation]
-     {:confusion-matrix (.toMatrixString evaluation)
+     {:confusion-matrix (try (.toMatrixString evaluation) (catch Exception e nil))
       :summary (.toSummaryString evaluation)
       :correct (try-metric #(.correct evaluation))
       :incorrect (try-metric #(.incorrect evaluation))

--- a/src/clj_ml/data.clj
+++ b/src/clj_ml/data.clj
@@ -24,6 +24,11 @@
 
 ;; Common functions
 
+(defn enumeration-or-nil-seq [s]
+  "Returns the result of enumeration-seq if the input sequence is not nil,
+  an empty list otherwise"
+  (if (nil? s) '() (enumeration-seq s)))
+
 (defn is-instance?
   "Checks if the provided object is an instance"
   [instance]
@@ -241,9 +246,9 @@
   "Returns map of the labels (possible values) for the given nominal attribute as the keys
    with the values being the attributes index. "
   [^Attribute attr]
-  (let [values (enumeration-seq (.enumerateValues attr))]
+  (let [values (enumeration-or-nil-seq (.enumerateValues attr))]
     (if (empty? values)
-      :not-nominal
+      {}
       (reduce (fn [m ^String val]
                 (assoc m (keyword val) (.indexOfValue attr val)))
               {}
@@ -252,12 +257,12 @@
 (defn attribute-labels
   "Returns the labels (possible values) for the given nominal attribute as keywords."
   [^Attribute attr]
-  (set (map keyword (enumeration-seq (.enumerateValues attr)))))
+  (set (map keyword (enumeration-or-nil-seq (.enumerateValues attr)))))
 
 (defn attribute-labels-as-strings
   "Returns the labels (possible values) for the given nominal attribute as strings."
   [^Attribute attr]
-  (set (enumeration-seq (.enumerateValues attr))))
+  (set (enumeration-or-nil-seq (.enumerateValues attr))))
 
 (defn dataset-labels-at [dataset-or-instance index-or-name]
   "Returns the lables (possible values) for a nominal attribute at the provided position"
@@ -276,7 +281,7 @@
    (fn [so-far ^Attribute attr]
      (conj so-far
            (if (.isNominal attr)
-             {(keyword-name attr) (map keyword (enumeration-seq (.enumerateValues attr)))}
+             {(keyword-name attr) (map keyword (enumeration-or-nil-seq (.enumerateValues attr)))}
              (keyword-name attr))))
    []
    (attributes dataset)))
@@ -375,7 +380,7 @@ If the class is nominal then the string value (not keyword) is returned."
   (if (= (class dataset)
          ClojureInstances)
     (seq dataset)
-    (seq (enumeration-seq (.enumerateInstances ^Instances dataset)))))
+    (seq (enumeration-or-nil-seq (.enumerateInstances ^Instances dataset)))))
 
 (defn dataset-as-maps
   "Returns a lazy sequence of the dataset represetned as maps.


### PR DESCRIPTION
Currently, when classifying datasets with numerical class attributes, some exceptions arise at evaluation. Some fixes have to be made in order to receive the evaluation map when calling `classifier-evaluate`.

This commit fixes these problems.