### PR TITLE
added support for Incremental Logit Boost classifier

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
 		 [nz.ac.waikato.cms.weka/rotationForest "1.0.3" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
 		 [nz.ac.waikato.cms.weka/paceRegression "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
 		 [nz.ac.waikato.cms.weka/SPegasos "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+		 [nz.ac.waikato.cms.weka/racedIncrementalLogitBoost "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
 		 [nz.ac.waikato.cms.weka/LibSVM "1.0.6" :exclusions [nz.ac.waikato.cms.weka/weka-dev tw.edu.ntu.csie/libsvm]]
 		 [junit/junit "4.11"]
                  [tw.edu.ntu.csie/libsvm "3.17"]

--- a/src/clj_ml/classifiers.clj
+++ b/src/clj_ml/classifiers.clj
@@ -65,7 +65,7 @@
            (weka.core Instance Instances)
            (weka.classifiers.lazy IBk)
            (weka.classifiers.trees J48 RandomForest M5P)
-           (weka.classifiers.meta LogitBoost AdditiveRegression RotationForest)
+           (weka.classifiers.meta LogitBoost AdditiveRegression RotationForest RacedIncrementalLogitBoost)
            (weka.classifiers.bayes NaiveBayes NaiveBayesUpdateable)
            (weka.classifiers.functions MultilayerPerceptron SMO LinearRegression Logistic PaceRegression SPegasos LibSVM)
            (weka.classifiers AbstractClassifier Classifier Evaluation)))
@@ -262,6 +262,17 @@
                         :unpruned "-N"})
       (check-option-values m {:minimum-instances "-M"}))))
 
+(defmethod make-classifier-options [:meta :raced-incremental-logit-boost]
+  ([kind algorithm m]
+     (->>
+       (check-options m { :use-resampling-for-boosting "-Q"
+                         :debug-mode "-D" })
+       (check-option-values m { :committee-pruning-to-perform "-P"
+                         :minimum-number-of-chunks "-C"
+                         :name-of-base-classifier "-W"
+                         :random-number-seed "-S"
+                         :size-of-validation-set "-V"
+                         :maximum-size-of-chunks "-M" }))))
 
 
 ;; Building classifiers
@@ -532,6 +543,10 @@
 (defmethod make-classifier [:decision-tree :m5p]
   ([kind algorithm & options]
      (make-classifier-with kind algorithm M5P options)))
+
+(defmethod make-classifier [:meta :raced-incremental-logit-boost]
+  ([kind algorithm & options]
+     (make-classifier-with kind algorithm RacedIncrementalLogitBoost options)))
 
 ;; Training classifiers
 

--- a/test/clj_ml/classifiers_test.clj
+++ b/test/clj_ml/classifiers_test.clj
@@ -119,3 +119,31 @@
     (classifier-update c ds)
     (classifier-update c inst)
     (is true)))
+
+(deftest make-classifiers-options-raced-incremental-logit-boost
+  (fact
+   (let [options (make-classifier-options
+                  :meta :raced-incremental-logit-boost
+                  { :use-resampling-for-boosting true :debug-mode true 
+                    :committee-pruning-to-perform 0 :minimum-number-of-chunks 200 
+                    :name-of-base-classifier "weka.classifiers.trees.DecisionStump" 
+                    :random-number-seed 20 :size-of-validation-set 200 
+                    :maximum-size-of-chunks 400 
+                   })]
+     options => (just ["-Q" "-D" "-P" "0" "-C" "200" "-W" "weka.classifiers.trees.DecisionStump" "-S" "20" "-V" "200" "-M" "400"] :in-any-order))))
+
+(deftest make-classifier-raced-incremental-logit-boost
+  (let [c (make-classifier :meta :raced-incremental-logit-boost)]
+    (is (= (class c)
+           weka.classifiers.meta.RacedIncrementalLogitBoost))))
+
+(deftest update-updateable-classifier-logit-boost
+  (let [c (clj-ml.classifiers/make-classifier :meta :raced-incremental-logit-boost)
+        ds (clj-ml.data/make-dataset "test" [:a :b {:c [:m :n]}] [[1 2 :m] [4 5 :m]])
+        _  (dataset-set-class ds 2)
+        inst (make-instance ds {:a 56 :b 45 :c :m})]
+    (classifier-train  c ds)
+    (classifier-update c ds)
+    (classifier-update c inst)
+    (is true)))
+


### PR DESCRIPTION
Hi,

I've added support for the incremental Logit Boost classifier from weka. 

Usage:

``` clojure

(ns energized-mist
  (:require 
            [clj-ml.data :as cd]
            [clj-ml.classifiers :as cls]))

(def classifier (cls/make-classifier :meta :raced-incremental-logit-boost {:size-of-validation-set 20 } ))

;;create dataset (def ds1 ...)

 (cls/classifier-train classifier ds1)

```