### PR TITLE
Add initialization-method parameter to k-means clusterer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,25 +4,24 @@
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :url "https://github.com/joshuaeckroth/clj-ml"
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [nz.ac.waikato.cms.weka/weka-dev "3.7.11"]
-		 [nz.ac.waikato.cms.weka/chiSquaredAttributeEval "1.0.4" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
-		 [nz.ac.waikato.cms.weka/attributeSelectionSearchMethods "1.0.7" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
-     [nz.ac.waikato.cms.weka/classifierBasedAttributeSelection "1.0.4" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
-		 [nz.ac.waikato.cms.weka/linearForwardSelection "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev nz.ac.waikato.cms.weka/classifierBasedAttributeSelection]]
-		 [nz.ac.waikato.cms.weka/rotationForest "1.0.3" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
-		 [nz.ac.waikato.cms.weka/paceRegression "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
-		 [nz.ac.waikato.cms.weka/SPegasos "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
-		 [nz.ac.waikato.cms.weka/racedIncrementalLogitBoost "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
-		 [nz.ac.waikato.cms.weka/LibSVM "1.0.6" :exclusions [nz.ac.waikato.cms.weka/weka-dev tw.edu.ntu.csie/libsvm]]
-		 [junit/junit "4.11"]
+                 [nz.ac.waikato.cms.weka/chiSquaredAttributeEval "1.0.4" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+                 [nz.ac.waikato.cms.weka/attributeSelectionSearchMethods "1.0.7" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+                 [nz.ac.waikato.cms.weka/classifierBasedAttributeSelection "1.0.4" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+                 [nz.ac.waikato.cms.weka/linearForwardSelection "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev nz.ac.waikato.cms.weka/classifierBasedAttributeSelection]]
+                 [nz.ac.waikato.cms.weka/rotationForest "1.0.3" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+                 [nz.ac.waikato.cms.weka/paceRegression "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+                 [nz.ac.waikato.cms.weka/SPegasos "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+                 [nz.ac.waikato.cms.weka/racedIncrementalLogitBoost "1.0.2" :exclusions [nz.ac.waikato.cms.weka/weka-dev]]
+                 [nz.ac.waikato.cms.weka/LibSVM "1.0.6" :exclusions [nz.ac.waikato.cms.weka/weka-dev tw.edu.ntu.csie/libsvm]]
+                 [junit/junit "4.11"]
                  [tw.edu.ntu.csie/libsvm "3.17"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.apache.lucene/lucene-analyzers-common "4.10.1"]
                  [org.apache.lucene/lucene-snowball "3.0.3"]]
-  :profiles {:dev
-             {:plugins [[lein-midje "3.1.3"]]
-              :dependencies [[midje "1.6.3"]]}}
+  :profiles {:dev {:plugins [[lein-midje "3.1.3"]]
+                   :dependencies [[midje "1.6.3"]]}}
   :codox {:output-dir "website/doc"
           :src-dir-uri "http://github.com/joshuaeckroth/clj-ml/blob/master"
           :src-linenum-anchor-prefix "L"}

--- a/src/clj_ml/clusterers.clj
+++ b/src/clj_ml/clusterers.clj
@@ -28,6 +28,7 @@
   ([kind m]
    (let [cols-val (check-options m {:display-standard-deviation "-V"
                                     :replace-missing-values "-M"
+                                    :initialization-method "-init"
                                     :preserve-instances-order "-O"}
                                  [""])
          cols-val-a (check-option-values m {:number-clusters "-N"

--- a/src/clj_ml/clusterers.clj
+++ b/src/clj_ml/clusterers.clj
@@ -105,6 +105,8 @@
              Seed for the random number generator. Sample value: 0.3
          - :number-iterations
              Maximum number of iterations that the algorithm will run. Sample value: 1000
+         - :initialization-method
+             Initialization method to use. 0 = random, 1 = k-means++, 2 = canopy, 3 = farthest first. (default = 0)
 
      * :cobweb
 

--- a/src/clj_ml/clusterers.clj
+++ b/src/clj_ml/clusterers.clj
@@ -11,8 +11,7 @@
 
    Some of these algorithms support incremental building of the clustering without
    having the full data set in main memory. Functions for evaluating the clusterer
-   as well as for clustering new instances are also supported
-"
+   as well as for clustering new instances are also supported"
   (:use [clj-ml utils data distance-functions options-utils])
   (:import (java.util Date Random)
            (weka.clusterers ClusterEvaluation SimpleKMeans Cobweb EM)))
@@ -27,53 +26,53 @@
 
 (defmethod make-clusterer-options :k-means
   ([kind m]
-     (let [cols-val (check-options m {:display-standard-deviation "-V"
-                                      :replace-missing-values "-M"
-                                      :preserve-instances-order "-O"}
-                                   [""])
-           cols-val-a (check-option-values m {:number-clusters "-N"
-                                              :random-seed "-S"
-                                              :number-iterations "-I"}
-                                           cols-val)]
-       (into-array cols-val-a))))
+   (let [cols-val (check-options m {:display-standard-deviation "-V"
+                                    :replace-missing-values "-M"
+                                    :preserve-instances-order "-O"}
+                                 [""])
+         cols-val-a (check-option-values m {:number-clusters "-N"
+                                            :random-seed "-S"
+                                            :number-iterations "-I"}
+                                         cols-val)]
+     (into-array cols-val-a))))
 
 
 (defmethod make-clusterer-options :cobweb
   ([kind m]
-     (let [cols-val-a (check-option-values m {:acuity "-A"
-                                              :cutoff "-C"
-                                              :random-seed "-S"}
-                                           [""])]
-       (into-array cols-val-a))))
+   (let [cols-val-a (check-option-values m {:acuity "-A"
+                                            :cutoff "-C"
+                                            :random-seed "-S"}
+                                         [""])]
+     (into-array cols-val-a))))
 
 
 (defmethod make-clusterer-options :expectation-maximization
   ([kind m]
-     (let [cols-val-a (check-option-values m {:number-clusters "-N"
-                                              :maximum-iterations "-I"
-                                              :minimum-standard-deviation "-M"
-                                              :random-seed "-S"}
-                                           [""])]
-       (into-array cols-val-a))))
+   (let [cols-val-a (check-option-values m {:number-clusters "-N"
+                                            :maximum-iterations "-I"
+                                            :minimum-standard-deviation "-M"
+                                            :random-seed "-S"}
+                                         [""])]
+     (into-array cols-val-a))))
 
 
 ;; Building clusterers
 
 (defmacro make-clusterer-m
   ([kind clusterer-class options]
-     `(let [options-read# (if (empty? ~options)  {} (first ~options))
-            clusterer# (new ~clusterer-class)
-            opts# (make-clusterer-options ~kind options-read#)]
-        (.setOptions clusterer# opts#)
-        (when (not (empty? (get options-read# :distance-function)))
-          ;; We have to setup a different distance function
-          (let [dist# (get options-read# :distance-function)
-                real-dist# (if (map? dist#)
-                             (make-distance-function (first (keys dist#))
-                                                     (first (vals dist#)))
-                             dist#)]
-            (.setDistanceFunction clusterer# real-dist#)))
-        clusterer#)))
+   `(let [options-read# (if (empty? ~options)  {} (first ~options))
+          clusterer# (new ~clusterer-class)
+          opts# (make-clusterer-options ~kind options-read#)]
+      (.setOptions clusterer# opts#)
+      (when (not (empty? (get options-read# :distance-function)))
+        ;; We have to setup a different distance function
+        (let [dist# (get options-read# :distance-function)
+              real-dist# (if (map? dist#)
+                           (make-distance-function (first (keys dist#))
+                                                   (first (vals dist#)))
+                           dist#)]
+          (.setDistanceFunction clusterer# real-dist#)))
+      clusterer#)))
 
 (defmulti make-clusterer
   "Creates a new clusterer for the given kind algorithm and options.
@@ -134,22 +133,21 @@
          - :minimum-standard-deviation
              Minimum allowable standard deviation for normal density computation. Default value: 1e-6
          - :random-seed
-             Seed for the random number generator. Default value: 100
-   "
+             Seed for the random number generator. Default value: 100"
   (fn [kind & options] kind))
 
 
 (defmethod make-clusterer :k-means
   ([kind & options]
-     (make-clusterer-m kind SimpleKMeans options)))
+   (make-clusterer-m kind SimpleKMeans options)))
 
 (defmethod make-clusterer :cobweb
   ([kind & options]
-     (make-clusterer-m kind Cobweb options)))
+   (make-clusterer-m kind Cobweb options)))
 
 (defmethod make-clusterer :expectation-maximization
   ([kind & options]
-     (make-clusterer-m kind EM options)))
+   (make-clusterer-m kind EM options)))
 
 
 ;; Clustering data
@@ -157,19 +155,19 @@
 (defn clusterer-build
   "Applies a clustering algorithm to a set of data"
   ([clusterer dataset]
-     (.buildClusterer clusterer dataset)))
+   (.buildClusterer clusterer dataset)))
 
 (defn clusterer-update
   "If the clusterer is updateable it updates the cluster with the given instance or set of instances"
   ([clusterer instance-s]
-     (if (is-dataset? instance-s)
-       (do (for [i (dataset-seq instance-s)]
-             (.updateClusterer clusterer i))
-           (.updateFinished clusterer)
-           clusterer)
-       (do (.updateClusterer clusterer instance-s)
-           (.updateFinished clusterer)
-           clusterer))))
+   (if (is-dataset? instance-s)
+     (do (for [i (dataset-seq instance-s)]
+           (.updateClusterer clusterer i))
+         (.updateFinished clusterer)
+         clusterer)
+     (do (.updateClusterer clusterer instance-s)
+         (.updateFinished clusterer)
+         clusterer))))
 
 ;; Retrieving information from a clusterer
 
@@ -179,27 +177,27 @@
 
 (defmethod clusterer-info SimpleKMeans
   ([clusterer]
-     "Accepts a k-means clusterer
+   "Accepts a k-means clusterer
       Returns a map with:
        :number-clusters The number of clusters in the clusterer
        :centroids       Map with the identifier and the centroid values for each cluster
        :cluster-sizes   Number of data points classified in each cluster
        :squared-error   Minimized squared error"
-     {:number-clusters (.numberOfClusters clusterer)
-      :centroids (second
-                  (reduce (fn [acum item]
-                            (let [counter (first acum)
-                                  map     (second acum)]
-                              (list (+ counter 1)
-                                    (conj map {counter item}))))
-                          (list 0 {})
-                          (dataset-seq (.getClusterCentroids clusterer))))
-      :cluster-sizes (let [sizes (.getClusterSizes clusterer)]
-                       (reduce (fn [acum item]
-                                 (conj acum {item (aget sizes item)}))
-                               {}
-                               (range 0 (.numberOfClusters clusterer))))
-      :squared-error (.getSquaredError clusterer)}))
+   {:number-clusters (.numberOfClusters clusterer)
+    :centroids (second
+                (reduce (fn [acum item]
+                          (let [counter (first acum)
+                                map     (second acum)]
+                            (list (+ counter 1)
+                                  (conj map {counter item}))))
+                        (list 0 {})
+                        (dataset-seq (.getClusterCentroids clusterer))))
+    :cluster-sizes (let [sizes (.getClusterSizes clusterer)]
+                     (reduce (fn [acum item]
+                               (conj acum {item (aget sizes item)}))
+                             {}
+                             (range 0 (.numberOfClusters clusterer))))
+    :squared-error (.getSquaredError clusterer)}))
 
 
 
@@ -208,14 +206,14 @@
 (defn- collect-evaluation-results
   "Collects all the statistics from the evaluation of a clusterer"
   ([evaluation]
-     (do
-       (println (.clusterResultsToString evaluation))
-       {:classes-to-clusters (try-metric
-                              #(reduce (fn [acum i] (conj acum {i (aget (.getClassesToClusters evaluation) i)}))
-                                       {}
-                                       (range 0 (.getNumClusters evaluation))))
-        :log-likelihood (try-metric #(.getLogLikelihood evaluation))
-        :evaluation-object evaluation})))
+   (do
+     (println (.clusterResultsToString evaluation))
+     {:classes-to-clusters (try-metric
+                            #(reduce (fn [acum i] (conj acum {i (aget (.getClassesToClusters evaluation) i)}))
+                                     {}
+                                     (range 0 (.getNumClusters evaluation))))
+      :log-likelihood (try-metric #(.getLogLikelihood evaluation))
+      :evaluation-object evaluation})))
 
 
 (defmulti clusterer-evaluate
@@ -224,22 +222,22 @@
 
 (defmethod clusterer-evaluate :dataset
   ([clusterer mode & evaluation-data]
-     (let [test-data (nth evaluation-data 0)
-           evaluation (do (let [evl (new ClusterEvaluation)]
-                            (.setClusterer evl clusterer)
-                            evl))]
-       (.evaluateClusterer evaluation test-data)
-       (println (.clusterResultsToString evaluation))
-       (collect-evaluation-results evaluation))))
+   (let [test-data (nth evaluation-data 0)
+         evaluation (do (let [evl (new ClusterEvaluation)]
+                          (.setClusterer evl clusterer)
+                          evl))]
+     (.evaluateClusterer evaluation test-data)
+     (println (.clusterResultsToString evaluation))
+     (collect-evaluation-results evaluation))))
 
 (defmethod clusterer-evaluate :cross-validation
   ([clusterer mode & evaluation-data]
-     (let [training-data (nth evaluation-data 0)
-           folds (nth evaluation-data 1)
-           evaluation (doto (new ClusterEvaluation) (.setClusterer clusterer))
-           log-likelihood (ClusterEvaluation/crossValidateModel
-                           clusterer training-data folds (new Random (.getTime (new Date))))]
-       {:log-likelihood log-likelihood})))
+   (let [training-data (nth evaluation-data 0)
+         folds (nth evaluation-data 1)
+         evaluation (doto (new ClusterEvaluation) (.setClusterer clusterer))
+         log-likelihood (ClusterEvaluation/crossValidateModel
+                         clusterer training-data folds (new Random (.getTime (new Date))))]
+     {:log-likelihood log-likelihood})))
 
 
 ;; Clustering collections
@@ -247,13 +245,13 @@
 (defn clusterer-cluster
   "Add a class to each instance according to the provided clusterer"
   ([clusterer dataset]
-     (let [attributes (conj (clj-ml.data/dataset-format dataset)
-                            {:class (map #(keyword (str %1)) (range 0 (.numberOfClusters clusterer)))})
-           clustered (map (fn [i] (conj (instance-to-vector i)
-                                        (keyword (str (.clusterInstance clusterer i)))))
-                          (dataset-seq dataset))
-           nds (make-dataset (keyword (str "clustered " (dataset-name dataset)))
-                             attributes
-                             clustered)]
-       (dataset-set-class nds (- (count attributes) 1))
-       nds)))
+   (let [attributes (conj (clj-ml.data/dataset-format dataset)
+                          {:class (map #(keyword (str %1)) (range 0 (.numberOfClusters clusterer)))})
+         clustered (map (fn [i] (conj (instance-to-vector i)
+                                      (keyword (str (.clusterInstance clusterer i)))))
+                        (dataset-seq dataset))
+         nds (make-dataset (keyword (str "clustered " (dataset-name dataset)))
+                           attributes
+                           clustered)]
+     (dataset-set-class nds (- (count attributes) 1))
+     nds)))

--- a/src/clj_ml/clusterers.clj
+++ b/src/clj_ml/clusterers.clj
@@ -21,22 +21,21 @@
 
 (defmulti #^{:skip-wiki true}
   make-clusterer-options
-  "Creates ther right parameters for a clusterer"
+  "Creates the right parameters for a clusterer"
   (fn [kind map] kind))
 
 (defmethod make-clusterer-options :k-means
   ([kind m]
    (let [cols-val (check-options m {:display-standard-deviation "-V"
                                     :replace-missing-values "-M"
-                                    :initialization-method "-init"
                                     :preserve-instances-order "-O"}
                                  [""])
          cols-val-a (check-option-values m {:number-clusters "-N"
                                             :random-seed "-S"
+                                            :initialization-method "-init"
                                             :number-iterations "-I"}
                                          cols-val)]
      (into-array cols-val-a))))
-
 
 (defmethod make-clusterer-options :cobweb
   ([kind m]

--- a/test/clj_ml/clusterers_test.clj
+++ b/test/clj_ml/clusterers_test.clj
@@ -5,8 +5,8 @@
 (deftest make-clusterers-options-k-means
   (fact
    (let [options (vec (make-clusterer-options :k-means {:display-standard-deviation true :replace-missing-values true :preserve-instances-order true
-                                                        :number-clusters 3 :random-seed 2 :number-iterations 1}))]
-     options => (just ["" "-V" "-M" "-O" "-N" "3" "-S" "2" "-I" "1"] :in-any-order))))
+                                                        :number-clusters 4 :initialization-method 3 :random-seed 2 :number-iterations 1}))]
+     options => (just ["" "-V" "-M" "-O" "-N" "4" "-init" "3" "-S" "2" "-I" "1"] :in-any-order))))
 
 (deftest make-clusterers-options-expectation-maximization
   (fact
@@ -51,3 +51,11 @@
     (clusterer-build c ds)
     (clusterer-evaluate c :cross-validation ds 2)
     (is true)))
+
+(deftest test-kmeans-clusterer-initialization-option
+  (let [ds (make-dataset :test [:a :b] [[1 1]
+                                        [2 2]
+                                        [3 3]])
+        c (make-clusterer :k-means {:initialization-method 2})]
+    (clusterer-build c ds)
+    (is (= "2" (.toString (.getInitializationMethod c))))))


### PR DESCRIPTION
I needed the [SimpleKMeans](http://weka.sourceforge.net/doc.dev/weka/clusterers/SimpleKMeans.html) option `-init`:

>   Initialization method to use.
>   0 = random, 1 = k-means++, 2 = canopy, 3 = farthest first.
>   (default = 0)

...so I added it. I modified an existing test and added a new one to boot. I bumped the Clojure version and made a few minor formatting fixes while I was in there. I hope that's okay.