### PR TITLE
 configuration options for random forest classifier

### DIFF
--- a/src/clj_ml/classifiers.clj
+++ b/src/clj_ml/classifiers.clj
@@ -232,12 +232,19 @@
 (defmethod make-classifier-options [:decision-tree :random-forest]
   ([kind algorithm m]
    (->>
-    (check-options m {:debug "-D"})
+    (check-options m {:debug "-D"
+                      :break-ties "-B"
+                      })
     (check-option-values m
                          {:num-trees-in-forest "-I"
                           :num-features-to-consider "-K"
                           :random-seed "-S"
-                          :depth "-depth"}))))
+                          :depth "-depth"
+                          :size-of-bag "-P"
+                          :parallelism "-num-slots" 
+                          :min-num-instance-per-leaf "-M"
+                          :min-variance-for-split "-V"
+                          }))))
 
 (defmethod make-classifier-options [:decision-tree :rotation-forest]
   ([kind algorithm m]

--- a/test/clj_ml/classifiers_test.clj
+++ b/test/clj_ml/classifiers_test.clj
@@ -168,3 +168,11 @@
   (let [c (make-classifier :regression :partial-least-squares)]
     (is (= (class c)
            weka.classifiers.functions.PLSClassifier))))
+
+(deftest make-classifier-random-forest
+  (let [c (make-classifier :decision-tree :random-forest
+                           {:num-trees-in-forest 10
+                            :parallelism 2}
+                           )]
+    (is (= (class c)
+           weka.classifiers.trees.RandomForest))))


### PR DESCRIPTION
Added support for the following options in creating a RandomForest Classifier

```
:size-of-bag "-P"
:parallelism "-num-slots"
:min-num-instance-per-leaf "-M"
:min-variance-for-split "-V"
```
More documentation on the [API page](http://weka.sourceforge.net/doc.dev/weka/classifiers/trees/RandomForest.html)
