### PR TITLE
 fixed invalid options for boosted stump and added missing options

### DIFF
--- a/src/clj_ml/classifiers.clj
+++ b/src/clj_ml/classifiers.clj
@@ -224,9 +224,8 @@
                               :num-iterations "-I"
                               :random-seed "-S"
                               :percentage-weight-mass "-P"
-                              :folds-for-cross-validation "-F"
-                              :runs-for-cross-validation "-R"
                               :log-likelihood-improvement-threshold "-L"
+                              :z-max-threshold-for-responses "-Z"
                               :shrinkage-parameter "-H"}))))
 
 (defmethod make-classifier-options [:decision-tree :random-forest]

--- a/test/clj_ml/classifiers_test.clj
+++ b/test/clj_ml/classifiers_test.clj
@@ -200,3 +200,16 @@
                            )]
     (is (= (class c)
            weka.classifiers.meta.Stacking))))
+
+(deftest make-classifier-boosted-stump
+  (let [c (make-classifier :decision-tree :boosted-stump
+                           {:weak-learning-class "weka.classifiers.trees.DecisionStump"
+                              :num-iterations 10 
+                              :random-seed 29 
+                              :percentage-weight-mass 90 
+                              :log-likelihood-improvement-threshold 0.9 
+                              :z-max-threshold-for-responses 3 
+                              :shrinkage-parameter 1}
+                           )]
+    (is (= (class c)
+           weka.classifiers.meta.LogitBoost))))


### PR DESCRIPTION
According to [the docs](http://weka.sourceforge.net/doc.dev/weka/classifiers/meta/LogitBoost.html), 
a couple of options for LogitBoost were incorrect. Fixed the same and added a test