### PR TITLE
Add :print-classifiers option to random forest

### DIFF
--- a/src/clj_ml/classifiers.clj
+++ b/src/clj_ml/classifiers.clj
@@ -233,6 +233,7 @@
    (->>
     (check-options m {:debug "-D"
                       :break-ties "-B"
+                      :print-classifiers "-print"
                       })
     (check-option-values m
                          {:num-trees-in-forest "-I"


### PR DESCRIPTION
This PR adds a new option to the random forest classifier to allow access to the underlying decision trees in the forest. When this option is enabled, the trees can be accessed by stringifying the classifier.