### PR TITLE
Fix option-squashing bug in make-apply-filter

### DIFF
--- a/src/clj_ml/filters.clj
+++ b/src/clj_ml/filters.clj
@@ -653,7 +653,7 @@
    The application of this filter is equivalent to the consecutive application of
    make-filter and apply-filter."
   [kind options dataset]
-  (let [opts (if (nil? (:dataset-format options)) (conj options {:dataset-format dataset}))
+  (let [opts (cond-> options (nil? (:dataset-format options)) (conj {:dataset-format dataset}))
         filter (make-filter kind opts)]
     (filter-apply filter dataset)))
 


### PR DESCRIPTION
This PR fixes a bug in make-apply-filter that sets opts to nil if :dataset-format exists in options (there's no "else" case specified in the conditional). 

With this change, options is passed through unchanged if :dataset-format is set.